### PR TITLE
Bump alleyinteractive/wordpress-autoloader to 0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "alleyinteractive/composer-wordpress-autoloader",
     "type": "composer-plugin",
-    "description": "Autoload files using WordPress File Conventions",
+    "description": "Autoload files using WordPress File Conventions using Composer",
     "license": "GPL-2.0-or-later",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "composer/composer": "*",
         "phpunit/phpunit": "^9.5.8",
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "extra": {
         "class": "ComposerWordPressAutoloader\\Plugin"

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php": "^7.4.0|^8.0|^8.1",
         "alleyinteractive/wordpress-autoloader": "^0.2",
-        "composer-plugin-api": "^2.0",
-        "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+        "composer-plugin-api": "^2.0"
     },
     "require-dev": {
         "composer/composer": "*",
-        "phpunit/phpunit": "^9.5.8"
+        "phpunit/phpunit": "^9.5.8",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "extra": {
         "class": "ComposerWordPressAutoloader\\Plugin"

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "alleyinteractive/wordpress-autoloader": "^0.1",
+        "php": "^7.4.0|^8.0|^8.1",
+        "alleyinteractive/wordpress-autoloader": "^0.2",
         "composer-plugin-api": "^2.0",
         "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "composer/composer": "*",
-        "phpunit/phpunit": "^8.5.8 || ^9.3.3"
+        "phpunit/phpunit": "^9.5.8"
     },
     "extra": {
         "class": "ComposerWordPressAutoloader\\Plugin"


### PR DESCRIPTION
- Bumping alleyinteractive/wordpress-autoloader to 0.2
- Bumping description
- Supports PHP 8.1
