### PR TITLE
Bump to 1.0 of WordPress loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.4.0|^8.0|^8.1",
-        "alleyinteractive/wordpress-autoloader": "^0.2",
+        "alleyinteractive/wordpress-autoloader": "^1.0",
         "composer-plugin-api": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bump to https://github.com/alleyinteractive/wordpress-autoloader/releases/tag/v1.0.0