### PR TITLE
Adding APCu Autoloader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,5 +46,10 @@ jobs:
           cd tests/fixtures/inject
           composer install
 
+      - name: Install APCu test dependencies
+        run: |
+          cd tests/fixtures/apcu
+          composer install
+
       - name: Execute tests
         run: composer run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ documented in this file.
 
 ## Unreleased
 
+## v0.7.0
+
+- Add APCu autoloader.
+- Bump `alleyinteractive/wordpress-autoloader` to `v1.1.0`.
+
 ## v0.6.0
 
 - Simplify injection of autoloader.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.4.0|^8.0|^8.1",
-        "alleyinteractive/wordpress-autoloader": "^1.0",
+        "alleyinteractive/wordpress-autoloader": "^1.1.0",
         "composer-plugin-api": "^2.0"
     },
     "require-dev": {

--- a/src/AutoloadFactory.php
+++ b/src/AutoloadFactory.php
@@ -6,12 +6,24 @@ use Alley_Interactive\Autoloader\Autoloader;
 
 class AutoloadFactory
 {
-  /**
-   * Generate an autoloader from a set of rules.
-   *
-   * @param array<string, array<string>> $rules Array of rules.
-   * @return array<Autoloader>
-   */
+    protected static ?string $apcuPrefix = null;
+
+    /**
+     * Set the APCu prefix to use.
+     *
+     * @param string|null $apcuPrefix|
+     */
+    public static function setApcuPrefix(?string $apcuPrefix): void
+    {
+        static::$apcuPrefix = $apcuPrefix;
+    }
+
+    /**
+     * Generate an autoloader from a set of rules.
+     *
+     * @param array<string, array<string>> $rules Array of rules.
+     * @return array<Autoloader>
+     */
     public static function generateFromRules(array $rules)
     {
         $loaders = [];
@@ -19,22 +31,27 @@ class AutoloadFactory
         foreach ($rules as $namespace => $paths) {
             $loaders = array_merge(
                 $loaders,
-                array_map(
-                    fn ($path) => new Autoloader($namespace, $path),
-                    $paths,
-                ),
+                array_map(function ($path) use ($namespace) {
+                    $loader = new Autoloader($namespace, $path);
+
+                    if (static::$apcuPrefix) {
+                        $loader->set_apcu_prefix(static::$apcuPrefix);
+                    }
+
+                    return $loader;
+                }, $paths),
             );
         }
 
         return $loaders;
     }
 
-  /**
-   * Register autoloaders from rules.
-   *
-   * @param array<string, string> $rules Array of rules.
-   * @return void
-   */
+    /**
+     * Register autoloaders from rules.
+     *
+     * @param array<string, string> $rules Array of rules.
+     * @return void
+     */
     public static function registerFromRules(array $rules)
     {
         foreach (static::generateFromRules($rules) as $autoloader) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -92,6 +92,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $this->io,
         );
 
+        $this->generator->setApcu(
+            $this->composer->getConfig()->get('apcu-autoloader')
+        );
+
         // Merge default configuration with the one provided in the composer.json file.
         $extra = array_merge(
             [

--- a/tests/AutoloaderTest.php
+++ b/tests/AutoloaderTest.php
@@ -18,6 +18,10 @@ class AutoloaderTest extends TestCase
         if (!file_exists(__DIR__ . '/fixtures/inject/vendor/wordpress-autoload.php')) {
             throw new RuntimeException('"composer install" needs to be run in tests/fixtures/inject');
         }
+
+        if (!file_exists(__DIR__ . '/fixtures/apcu/vendor/wordpress-autoload.php')) {
+            throw new RuntimeException('"composer install" needs to be run in tests/fixtures/apcu');
+        }
     }
 
     public function testAutoloadedClass()

--- a/tests/AutoloaderTest.php
+++ b/tests/AutoloaderTest.php
@@ -59,7 +59,7 @@ class AutoloaderTest extends TestCase
 
     public function testAutoloaderFile()
     {
-        $expected = '917584115f2659b859cfcac9a55d7816';
+        $expected = '9893efd7d77972c681f2693e9d20a975';
         $actual = md5(file_get_contents(__DIR__ . '/fixtures/root/vendor/wordpress-autoload.php'));
 
         $this->assertEquals($expected, $actual);
@@ -73,5 +73,20 @@ class AutoloaderTest extends TestCase
         require_once __DIR__ . '/fixtures/inject/vendor/wordpress-autoload.php';
 
         $this->assertTrue(class_exists(\ComposerWordPressAutoloaderTests_Inject\Example_Class::class));
+    }
+
+    public function testApcuLoader()
+    {
+        // Ensure it is undefined until we load it.
+        $this->assertFalse(class_exists(\ComposerWordPressAutoloaderTests_APCu\Example_Class::class));
+
+        require_once __DIR__ . '/fixtures/apcu/vendor/wordpress-autoload.php';
+
+        $this->assertTrue(class_exists(\ComposerWordPressAutoloaderTests_APCu\Example_Class::class));
+
+        $this->assertStringContainsString(
+            'setApcuPrefix(',
+            file_get_contents(__DIR__ . '/fixtures/apcu/vendor/wordpress-autoload.php'),
+        );
     }
 }

--- a/tests/fixtures/apcu/composer.json
+++ b/tests/fixtures/apcu/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "alleyinteractive/composer-wordpress-autoload-tests-apcu",
+    "type": "project",
+    "license": "GPL",
+    "authors": [
+        {
+            "name": "Alley Interactive",
+            "email": "info@alley.co"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {
+        "alleyinteractive/composer-wordpress-autoloader": "*"
+    },
+    "autoload": {
+        "wordpress": {
+            "ComposerWordPressAutoloaderTests_APCu\\": "src/"
+        }
+    },
+    "repositories": {
+        "composer-wordpress-autoload": {
+            "options": {
+                "symlink": false
+            },
+            "type": "path",
+            "url": "../../../"
+        }
+    },
+    "config": {
+        "apcu-autoloader": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "alleyinteractive/composer-wordpress-autoloader": true
+        }
+    }
+}

--- a/tests/fixtures/apcu/src/class-example-class.php
+++ b/tests/fixtures/apcu/src/class-example-class.php
@@ -1,0 +1,5 @@
+<?php
+namespace ComposerWordPressAutoloaderTests_APCu;
+
+class Example_Class {
+}


### PR DESCRIPTION
- Adding support for caching the autoloader with APCu when using the plugin.
- Switches to `alleyinteractive/wordpress-autoloader` v1.1.0 https://github.com/alleyinteractive/wordpress-autoloader/pull/13