### PR TITLE
Renaming setApcu to avoid conflict with 2.1 composer

### DIFF
--- a/src/AutoloadGenerator.php
+++ b/src/AutoloadGenerator.php
@@ -50,7 +50,7 @@ class AutoloadGenerator extends ComposerAutoloadGenerator
      * @param string|null $apcuPrefix
      * @return void
      */
-    public function setApcu(bool $apcu, ?string $apcuPrefix = null)
+    public function setApcuMode(bool $apcu, ?string $apcuPrefix = null)
     {
         parent::setApcu($apcu, $apcuPrefix);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -92,7 +92,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $this->io,
         );
 
-        $this->generator->setApcu(
+        $this->generator->setApcuMode(
             $this->composer->getConfig()->get('apcu-autoloader')
         );
 


### PR DESCRIPTION
Renaming a non-external method name to avoid conflicting with Composer 2.1.

Composer 2.1 renamed the method name of `AutoloadGenerator::setApcu()` in https://github.com/composer/composer/commit/6da38f83a0d5acc71793f337b525fa2faff9468e.