### PR TITLE
Use ClassMapGenerator inline. Fix #4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "composer/composer": "*",
+        "nikic/php-parser": "^4.15",
         "phpunit/phpunit": "^9.5.8",
         "squizlabs/php_codesniffer": "^4.0"
     },

--- a/tests/AutoloaderTest.php
+++ b/tests/AutoloaderTest.php
@@ -152,7 +152,7 @@ class AutoloaderTest extends TestCase
                 }
             }
 
-            if ($ast_index > count($ast)) {
+            if ($ast_index >= $ast_entries_count) {
                 break;
             }
         }

--- a/tests/AutoloaderTest.php
+++ b/tests/AutoloaderTest.php
@@ -2,6 +2,9 @@
 
 namespace ComposerWordPressAutoloader\Tests;
 
+use Error;
+use PhpParser\NodeDumper;
+use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -82,12 +85,83 @@ class AutoloaderTest extends TestCase
         ];
     }
 
+    /**
+     * Parse the generated PHP text file using PHP-Parser and check the file contains the expected variables
+     * and function calls in the expected order.
+     *
+     * @see https://github.com/nikic/PHP-Parser
+     *
+     * The generated file should have:
+     * * autoload assign
+     * * vendor dir assign
+     * * basedir assign
+     * * classmap array
+     * * spl_autoload_register call
+     */
     public function testAutoloaderFile()
     {
-        $expected = '9893efd7d77972c681f2693e9d20a975';
-        $actual = md5(file_get_contents(__DIR__ . '/fixtures/root/vendor/wordpress-autoload.php'));
+        $code = file_get_contents(__DIR__ . '/fixtures/root/vendor/wordpress-autoload.php');
 
-        $this->assertEquals($expected, $actual);
+        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $ast = $parser->parse($code);
+
+        // We'll check each parsed expression and use the index to make sure things are in order.
+        $ast_index = 0;
+
+        /** @var array<array<string,array<string>>> $expected The expected value and its key paths. */
+        $expected = array(
+            array( 'autoload' => array( 'expr', 'var', 'name' )),
+            array( 'vendorDir'  => array( 'expr', 'var', 'name' )),
+            array( 'baseDir' => array( 'expr', 'var', 'name' ) ),
+            array( 'wordpress_classmap'  => array( 'expr', 'var', 'name' )),
+            array( 'spl_autoload_register' => array( 'expr', 'name', 'parts', 0 ) ),
+        );
+
+        /** @var bool[] $found An empty array of `false` indicating was the $expected entry found. */
+        $found = array_map(function () {
+            return false;
+        }, $expected);
+
+        $ast_entries_count = count($ast);
+
+        foreach ($expected as $found_index => $sequential_item) {
+            $expected_value = array_key_first($sequential_item);
+            $key_path = $sequential_item[$expected_value];
+
+            for ($inner_ast_index = $ast_index; $inner_ast_index < $ast_entries_count; $inner_ast_index++) {
+                $ast_index++;
+
+                $ast_entry = $ast[$inner_ast_index];
+                $value = $ast_entry;
+
+                foreach ($key_path as $path) {
+                    if (is_object($value) && isset($value->$path)) {
+                        $value = $value->$path;
+                    } elseif (is_array($value) && isset($value[$path])) {
+                        $value = $value[$path];
+                    } else {
+                        // This entry in the AST is not what we're looking for.
+                        // It may just be a trivial assignment we're not concerned with.
+                        continue 2;
+                    }
+                }
+
+                if ($expected_value === $value) {
+                    $found[$found_index] = true;
+                    continue 2;
+                }
+            }
+
+            if ($ast_index > count($ast)) {
+                break;
+            }
+        }
+
+        $all_found = array_reduce($found, function ($carry, $actual) {
+            return $carry && $actual;
+        }, true);
+
+        $this->assertTrue($all_found);
     }
 
     public function testApcuLoader()


### PR DESCRIPTION
Nice.

It seems you're adding your package as normal, and it has a `files` `autoload` key which points to a `.php` file that `include`s a .`php` file you generate on `post-dump-autoload` hook, which runs on `composer install` etc.

I like it. 

My only comment is that it places the file at `vendor/wordpress-autoload.php`, whereas `vendor/composer/autoload_classmap.php` and `vendor/composer/autoload_psr4.php` are the convention. But it's a bit inappropriate to edit files in someone else's directory.

So, since you're already generating that, and it generates on `dump-autoload` the easiest way to add a classmap is to do it during the same operation, and register the `spl` autoloader before the `ComposerWordPressAutoloader` one in the same file.

This was a little rushed from excitement (e.g. I used WordPress code style; untested with sub-packages; no tests). I only saw this project today, but I expect I'll be using it regularly soon.