### PR TITLE
Resolve the vendor/wordpress-autoload.php file on Windows, add PHP 8.1-8.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1, 8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-2019]
         php: [8.0, 8.1, 8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,5 +48,9 @@ jobs:
       - name: Install vendor-dir test dependencies
         run: cd tests/fixtures/vendor-dir && composer install
 
-      - name: Execute tests
-        run: composer run test
+      - name: Execute phpcs
+        if: matrix.os != 'windows-2019'
+        run: composer run phpcs
+
+      - name: Execute phpunit
+        run: composer run phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ documented in this file.
 
 ## Unreleased
 
+## v1.1.0
+
+### Changed
+
+- Dropped PHP 7.4 support, adding PHP 8.2 and 3 support explicitly with testing.
+- Added testing against Windows.
+
+### Fixed
+
+- Fixed issue with missing autoloaded file not found when using `vendor/autoload.php`.
+
+## v1.0.0
+
+No changes, tagging a stable release.
+
 ## v0.8.0
 
 - Automatically translate the `vendor-dir` and set the autoloaded files relative to the root directory of the project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ documented in this file.
 
 ### Fixed
 
-- Fixed issue with missing autoloaded file not found when using `vendor/autoload.php`.
+- Fixed issue with `wordpress-autoload.php` file not properly loading on Windows.
 
 ## v1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ documented in this file.
 
 ### Changed
 
-- Dropped PHP 7.4 support, adding PHP 8.2 and 3 support explicitly with testing.
+- Dropped PHP 7.4 support, adding PHP 8.2 and 8.3 support explicitly with testing.
 - Added testing against Windows.
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.4.0|^8.0|^8.1",
+        "php": "^8.0",
         "alleyinteractive/wordpress-autoloader": "^1.1.1",
         "composer-plugin-api": "^2.0"
     },

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -7,7 +7,17 @@
  */
 
 $autoloadFiles = [
+    // Attempt to translate the /vendor/ in the directory path to the vendor directory.
     preg_replace('#/vendor/.*$#', '/vendor/wordpress-autoload.php', __DIR__),
+    preg_replace('/\\\vendor\\\.*$/', '/vendor/wordpress-autoload.php', __DIR__),
+
+    // Assuming this file is located at
+    // vendor/alleyinteractive/composer-wordpress-autoloader/src/autoload.php,
+    // hop up a few directories and try to load the file from there.
+    dirname(__DIR__, 3) . '/wordpress-autoload.php',
+
+    // Handle local development of the package where vendor directory is closer
+    // to the root.
     '../../../vendor/wordpress-autoload.php',
     '../../vendor/wordpress-autoload.php',
 ];

--- a/tests/AutoloaderTest.php
+++ b/tests/AutoloaderTest.php
@@ -84,6 +84,10 @@ class AutoloaderTest extends TestCase
 
     public function testAutoloaderFile()
     {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Skipping test on Windows');
+        }
+
         $expected = '9893efd7d77972c681f2693e9d20a975';
         $actual = md5(file_get_contents(__DIR__ . '/fixtures/root/vendor/wordpress-autoload.php'));
 


### PR DESCRIPTION
## Changed

- Dropped PHP 7.4 support, adding PHP 8.2 and 3 support explicitly with testing.
- Added testing against Windows.

## Fixed

- Fixed issue with `wordpress-autoload.php` file not properly loading on Windows.

Fixes #28 